### PR TITLE
Wrap messages in text to avoid interpreting as markdown

### DIFF
--- a/src/LoggingStream.jl
+++ b/src/LoggingStream.jl
@@ -35,7 +35,8 @@ function Base.unsafe_write(s::LoggingStream, p::Ptr{UInt8}, n::UInt)
             level >= s.logstate.min_enabled_level &&
             Logging.shouldlog(s.logger, level, _module, group, id)
         m = (n > 0 && unsafe_load(p, n) == UInt8('\n')) ? n-1 : n
-        message = unsafe_string(p, m)
+        # Wrap in Text to force plain rather than markdown text
+        message = Text(unsafe_string(p, m))
         Logging.handle_message(s.logger, level, message, _module, group, id, file, line)
     end
     # Could support some approximation of dynamic scoping with the following,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,9 +38,9 @@ end
 end
 
 @testset "LoggingStream" begin
-    @test_logs (:info, "L1",     Logging, Ignored(), :asdf) #=
-            =# (:info, "L2",     Logging, Ignored(), :asdf) #=
-            =# (:info, "L3\nL4", Logging, Ignored(), :asdf) #=
+    @test_logs (:info, Text("L1"),     Logging, Ignored(), :asdf) #=
+            =# (:info, Text("L2"),     Logging, Ignored(), :asdf) #=
+            =# (:info, Text("L3\nL4"), Logging, Ignored(), :asdf) #=
     =# begin
         ls = Logging2.LoggingStream(current_logger(), id=:asdf)
         write(ls, "L1")
@@ -56,7 +56,8 @@ end
 end
 
 @testset "redirect_stdout and redirect_stderr" begin
-    @test_logs (:info,"Hi") (:info,"Hi2") (:info,"Hi3") (:info,"Hi4") #=
+    @test_logs (:info,Text("Hi"))  (:info,Text("Hi2")) #=
+        =#     (:info,Text("Hi3")) (:info,Text("Hi4")) #=
         =# redirect_stdout(current_logger()) do
             println("Hi")
             println("Hi2\nHi3")
@@ -66,17 +67,17 @@ end
         end
 
     # test return value from `redirect_stdout`
-    @test (@test_logs (:info,"Hi") redirect_stdout(current_logger()) do
+    @test (@test_logs (:info,Text("Hi")) redirect_stdout(current_logger()) do
         println("Hi")
         101
     end) == 101
 
-    @test_logs (:info,"Hi") #=
+    @test_logs (:info,Text("Hi")) #=
         =# redirect_stderr(current_logger()) do
             println(stderr, "Hi")
         end
 
-    @test_logs (:warn,"Hi") #=
+    @test_logs (:warn,Text("Hi")) #=
         =# redirect_stderr(current_logger(); level=Logging.Warn) do
             println(stderr, "Hi")
         end


### PR DESCRIPTION
In the current system, `AbstractString` is interpreted as markdown by default (at least, the official docs say that, and `TerminalLogger` follows through on it).

So wrap messages from streams in `Text` to avoid this.