### PR TITLE
Fix stdio redirections for the Julia 1.7 API  breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
       matrix:
         version:
           - '1.4'
-          - '1.5'
+          - '1.6'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Logging2"
 uuid = "18cd0bd4-3461-488c-9dae-1a490b172243"
 authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
Base.redirect_stdout etc are no longer generic functions, so it's not
possible to overload these anymore. Instead it's necessary to overload
the function object Base.RedirectStdStream.